### PR TITLE
Add workflow to auto-generate wheels for Linux, Windows and Mac OS

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019]
 
     steps:
       - uses: actions/checkout@v2
@@ -24,3 +24,18 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheels/*.whl
+
+  build_wheels_macos:
+    name: Build wheels on macos-11
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.8.1
+        env:
+          CIBW_ARCHS_MACOS: x86_64 universal2
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,26 @@
+name: Build Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.4.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheels
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheels/*.whl


### PR DESCRIPTION
Hi! I have added a workflow that generates wheels for all platforms automatically on all push's and pull request's. I feel that this would make it easier to install it.

The action generates a single artifacts zip file which can be manually downloaded and added to release (or chained to do that automatically too but that would get require token to be added to repo secrets)